### PR TITLE
fix value for parameter gamma

### DIFF
--- a/GA.py
+++ b/GA.py
@@ -26,7 +26,7 @@ def cal_pop_fitness(pop, features, labels, train_indices, test_indices):
         train_labels = labels[train_indices]
         test_labels = labels[test_indices]
 
-        SV_classifier = sklearn.svm.SVC(gamma='scale')
+        SV_classifier = sklearn.svm.SVC(gamma='auto')
         SV_classifier.fit(X=train_data, y=train_labels)
 
         predictions = SV_classifier.predict(test_data)


### PR DESCRIPTION
 If you look at the documentation for svm. SVC, you will see that gamma must be a number, not a string. (The string 'auto' is allowed, but only because it has special meaning for this particular function and not 'scale' anymore.)